### PR TITLE
Implement add connect_timeout config option and set it to 5s

### DIFF
--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -615,6 +615,7 @@ class FileCache implements FileCacheContract
     {
         return new Client([
             'timeout' => $this->config['timeout'],
+            'connect_timeout' => $this->config['connect_timeout'],
             'http_errors' => false,
         ]);
     }

--- a/src/config/file-cache.php
+++ b/src/config/file-cache.php
@@ -24,11 +24,18 @@ return [
     'path' => storage_path('framework/cache/files'),
 
     /*
-     | Read timeout in seconds for fetching remote files. If the stream transmits
-     | no data for longer than this period (or cannot be established), caching the
-     | file fails.
+     | Total connection timeout when reading remote files. If loading the
+     | file takes longer than this, it will fail.
+     | Default: 0 (indefinitely)
      */
-    'timeout' => env('FILE_CACHE_TIMEOUT', 5.0),
+    'timeout' => env('FILE_CACHE_TIMEOUT', 0),
+
+    /*
+     | Timeout to initiate a connection to load a remote file. If it takes
+     | longer, it will fail. Set to 0 to wait indefinitely.
+     | Default: 5.0
+     */
+    'connect_timeout' => env('FILE_CACHE_CONNECT_TIMEOUT', 5.0),
 
     /*
      | Interval for the scheduled task to prune the file cache.


### PR DESCRIPTION
The timeout option is set to 0. This should be a similar behavior to v4.0.1 again.