### PR TITLE
Fix disk leak of temporary files

### DIFF
--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -484,9 +484,12 @@ class FileCache implements FileCacheContract
     {
         if ($this->isRemote($file)) {
             $source = $this->getFileStream($file->getUrl());
-            $cachedPath = $this->cacheFromResource($file, $source, $handle);
-            if (is_resource($source)) {
-                fclose($source);
+            try {
+                $cachedPath = $this->cacheFromResource($file, $source, $handle);
+            } finally {
+                if (is_resource($source)) {
+                    fclose($source);
+                }
             }
         } else {
             $newCachedPath = $this->getDiskFile($file, $handle);
@@ -533,9 +536,12 @@ class FileCache implements FileCacheContract
             throw new Exception('File does not exist.');
         }
 
-        $cachedPath = $this->cacheFromResource($file, $source, $target);
-        if (is_resource($source)) {
-            fclose($source);
+        try {
+            $cachedPath = $this->cacheFromResource($file, $source, $target);
+        } finally {
+            if (is_resource($source)) {
+                fclose($source);
+            }
         }
 
         return $cachedPath;
@@ -612,7 +618,7 @@ class FileCache implements FileCacheContract
     protected function getFileStream($url)
     {
         if (strpos($url, 'http') === 0) {
-            return $this->client->get($url)->getBody()->detach();
+            return $this->client->get($url, ['stream' => true])->getBody()->detach();
         }
 
         return @fopen($url, 'r');

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -86,9 +86,13 @@ class FileCacheTest extends TestCase
         ]);
 
         $cache->stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('file is too large');
-        $cache->get($file, $this->noop);
+        try {
+            $cache->get($file, $this->noop);
+            $this->fail('Expected an Exception to be thrown.');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('file is too large', $e->getMessage());
+        }
+        $this->assertFalse(is_resource($cache->stream));
     }
 
     public function testGetDiskDoesNotExist()
@@ -154,7 +158,6 @@ class FileCacheTest extends TestCase
     {
         config(['filesystems.disks.s3' => ['driver' => 's3']]);
         $file = new GenericFile('s3://files/test-image.jpg');
-        $hash = hash('sha256', 's3://files/test-image.jpg');
 
         $stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
 
@@ -168,10 +171,13 @@ class FileCacheTest extends TestCase
             'max_file_size' => 1,
         ]);
 
-        $this->assertFalse($this->app['files']->exists("{$this->cachePath}/{$hash}"));
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('file is too large');
-        $path = $cache->get($file, $this->noop);
+        try {
+            $cache->get($file, $this->noop);
+            $this->fail('Expected an Exception to be thrown.');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('file is too large', $e->getMessage());
+        }
+        $this->assertFalse(is_resource($stream));
     }
 
     public function testGetThrowOnLock()


### PR DESCRIPTION
Guzzle saves large streams to /tmp. These could leak if there was an error in cacheFromResource. This fixes both the cleanup and also enables "true" streaming with Guzzle.