### PR TITLE
Fix getStream with remote URLs

### DIFF
--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -112,7 +112,11 @@ class FileCache implements FileCacheContract
         }
 
         if ($this->isRemote($file)) {
-            return $this->getFileStream($file->getUrl());
+            try {
+                return $this->getFileStream($file->getUrl());
+            } catch (BadResponseException $e) {
+                throw new Exception("The dile does not exist", previous: $e);
+            }
         }
 
         $url = explode('://', $file->getUrl());

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -8,6 +8,7 @@ use Biigle\FileCache\Exceptions\FileLockedException;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use RuntimeException;
@@ -293,7 +294,12 @@ class FileCache implements FileCacheContract
      */
     protected function existsRemote($file)
     {
-        $response = $this->client->head($file->getUrl());
+        try {
+            $response = $this->client->head($file->getUrl());
+        } catch (BadResponseException $e) {
+            return false;
+        }
+
         $code = $response->getStatusCode();
 
         if ($code < 200 || $code >= 300) {
@@ -656,7 +662,6 @@ class FileCache implements FileCacheContract
             'timeout' => $this->config['timeout'],
             'connect_timeout' => $this->config['connect_timeout'],
             'read_timeout' => $this->config['read_timeout'],
-            'http_errors' => false,
         ]);
     }
 }

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -111,7 +111,7 @@ class FileCache implements FileCacheContract
         }
 
         if ($this->isRemote($file)) {
-            return $this->getFileStream($cachedPath);
+            return $this->getFileStream($file->getUrl());
         }
 
         $url = explode('://', $file->getUrl());

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -8,6 +8,7 @@ use Biigle\FileCache\FileCache;
 use Biigle\FileCache\GenericFile;
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -254,7 +255,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(200, [], fopen(__DIR__.'/files/test-image.jpg', 'r'))]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack, 'http_errors' => false]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/image.jpg');
         $cache = new FileCache(['path' => $this->cachePath], client: $client);
@@ -262,6 +263,19 @@ class FileCacheTest extends TestCase
         $stream = $cache->getStream($file);
         $this->assertTrue(is_resource($stream));
         fclose($stream);
+    }
+
+    public function testGetStreamRemoteThrowsOnError()
+    {
+        $mock = new MockHandler([new Response(404)]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $file = new GenericFile('https://example.com/image.jpg');
+        $cache = new FileCache(['path' => $this->cachePath], client: $client);
+
+        $this->expectException(BadResponseException::class);
+        $cache->getStream($file);
     }
 
     public function testGetStreamDisk()
@@ -429,10 +443,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(404)]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client([
-            'handler' => $handlerStack,
-            'http_errors' => false,
-        ]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/file');
         $cache = new FileCache(['path' => $this->cachePath], client: $client);
@@ -443,10 +454,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(500)]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client([
-            'handler' => $handlerStack,
-            'http_errors' => false,
-        ]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/file');
         $cache = new FileCache(['path' => $this->cachePath], client: $client);
@@ -457,10 +465,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(200)]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client([
-            'handler' => $handlerStack,
-            'http_errors' => false,
-        ]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/file');
         $cache = new FileCache(['path' => $this->cachePath], client: $client);
@@ -471,10 +476,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(200, ['content-length' => 100])]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client([
-            'handler' => $handlerStack,
-            'http_errors' => false,
-        ]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/file');
         $cache = new FileCache([
@@ -494,10 +496,7 @@ class FileCacheTest extends TestCase
     {
         $mock = new MockHandler([new Response(200, ['content-type' => 'application/json'])]);
         $handlerStack = HandlerStack::create($mock);
-        $client = new Client([
-            'handler' => $handlerStack,
-            'http_errors' => false,
-        ]);
+        $client = new Client(['handler' => $handlerStack]);
 
         $file = new GenericFile('https://example.com/file');
         $cache = new FileCache([

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -8,7 +8,6 @@ use Biigle\FileCache\FileCache;
 use Biigle\FileCache\GenericFile;
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -274,7 +273,7 @@ class FileCacheTest extends TestCase
         $file = new GenericFile('https://example.com/image.jpg');
         $cache = new FileCache(['path' => $this->cachePath], client: $client);
 
-        $this->expectException(BadResponseException::class);
+        $this->expectException(Exception::class);
         $cache->getStream($file);
     }
 

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -252,10 +252,16 @@ class FileCacheTest extends TestCase
 
     public function testGetStreamRemote()
     {
-        $file = new GenericFile('https://files/test-image.jpg');
-        $cache = new FileCacheStub(['path' => $this->cachePath]);
-        $cache->stream = 'abc123';
-        $this->assertEquals('abc123', $cache->getStream($file));
+        $mock = new MockHandler([new Response(200, [], fopen(__DIR__.'/files/test-image.jpg', 'r'))]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack, 'http_errors' => false]);
+
+        $file = new GenericFile('https://example.com/image.jpg');
+        $cache = new FileCache(['path' => $this->cachePath], client: $client);
+
+        $stream = $cache->getStream($file);
+        $this->assertTrue(is_resource($stream));
+        fclose($stream);
     }
 
     public function testGetStreamDisk()


### PR DESCRIPTION
The method attempted to read a stream from the cached path instead of the actual URL which always returned false.