### PR TITLE
Implement new locking mechanism to avoid fd exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Fetch and cache files from local filesystem, cloud storage or public webservers in Laravel or Lumen.
 
-The file cache is specifically designed for use in concurrent processing with multiple parallel queue workers.
+The file cache is specifically designed for use in concurrent processing with multiple parallel queue workers and lots of files.
 
 [![Tests](https://github.com/biigle/laravel-file-cache/actions/workflows/tests.yml/badge.svg)](https://github.com/biigle/laravel-file-cache/actions/workflows/tests.yml)
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -665,6 +665,7 @@ class FileCache implements FileCacheContract
         }
 
         if (!flock($handle, LOCK_EX)) {
+            @unlink($path);
             throw new RuntimeException("Could not get lock on file {$path}");
         }
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -36,6 +36,15 @@ class FileCache implements FileCacheContract
     const REFS_DIR = '.refs';
 
     /**
+     * Maximum number of times retrieve() retries when the cached file keeps
+     * disappearing or is left empty by a failing writer. Bounds the retries so
+     * a persistently failing file cannot loop forever.
+     *
+     * @var integer
+     */
+    const MAX_RETRIEVE_ATTEMPTS = 10;
+
+    /**
      * Counter for reference links used to generate unique names per instance.
      *
      * @var integer
@@ -357,14 +366,15 @@ class FileCache implements FileCacheContract
     protected function existsDisk($file)
     {
         $url = explode('://', $file->getUrl());
-        $exists = $this->getDisk($file)->exists($url[1]);
+        $disk = $this->getDisk($file);
+        $exists = $disk->exists($url[1]);
 
         if (!$exists) {
             return false;
         }
 
         if (!empty($this->config['mime_types'])) {
-            $type = $this->getDisk($file)->mimeType($url[1]);
+            $type = $disk->mimeType($url[1]);
             if (!in_array($type, $this->config['mime_types'])) {
                 throw new Exception("MIME type '{$type}' not allowed.");
             }
@@ -373,7 +383,7 @@ class FileCache implements FileCacheContract
         $maxBytes = intval($this->config['max_file_size']);
 
         if ($maxBytes >= 0) {
-            $size = $this->getDisk($file)->size($url[1]);
+            $size = $disk->size($url[1]);
             if ($size > $maxBytes) {
                 throw new Exception("The file is too large with more than {$maxBytes} bytes.");
             }
@@ -436,6 +446,7 @@ class FileCache implements FileCacheContract
      *
      * @param File $file File to get the path for
      * @param bool $throwOnLock Whether to throw an exception if a file is currently locked (i.e. written to). Otherwise the method will wait until the lock is released.
+     * @param int $attempt Current retry attempt. Used internally to bound the recursion.
      * @throws Exception If the file could not be cached.
      * @throws FileLockedException If the file is locked and `throwOnLock` was `true`.
      *
@@ -443,8 +454,14 @@ class FileCache implements FileCacheContract
      * (or `null` for locally stored files). Unlink the reference link when
      * finished.
      */
-    protected function retrieve(File $file, bool $throwOnLock = false)
+    protected function retrieve(File $file, bool $throwOnLock = false, int $attempt = 0)
     {
+        // A file that keeps disappearing or is repeatedly left empty by a failing
+        // writer must not recurse forever.
+        if ($attempt >= self::MAX_RETRIEVE_ATTEMPTS) {
+            throw new Exception("Failed to retrieve file '{$file->getUrl()}' after ".self::MAX_RETRIEVE_ATTEMPTS." attempts.");
+        }
+
         $this->ensureDirExists($this->config['path']);
         $cachedPath = $this->getCachedPath($file);
 
@@ -454,7 +471,12 @@ class FileCache implements FileCacheContract
 
         if ($handle === false) {
             // The file exists, get the file handle in read mode.
-            $handle = fopen($cachedPath, 'r');
+            $handle = @fopen($cachedPath, 'r');
+            // The cached file may be deleted between the first fopen and now. Retry.
+            if ($handle === false) {
+                return $this->retrieve($file, $throwOnLock, $attempt + 1);
+            }
+
             if ($throwOnLock && !flock($handle, LOCK_SH | LOCK_NB)) {
                 fclose($handle);
                 throw new FileLockedException;
@@ -464,11 +486,16 @@ class FileCache implements FileCacheContract
             flock($handle, LOCK_SH);
 
             $stat = fstat($handle);
+            if ($stat === false) {
+                fclose($handle);
+                throw new RuntimeException("Could not stat cached file '{$cachedPath}'.");
+            }
+
             // Check if the file is still there since the writing operation could have
             // failed. If the file is gone, retry retrieve.
             if ($stat['nlink'] === 0) {
                 fclose($handle);
-                return $this->retrieve(...func_get_args());
+                return $this->retrieve($file, $throwOnLock, $attempt + 1);
             }
 
             // File caching may have failed and left an empty file in the cache.
@@ -476,7 +503,7 @@ class FileCache implements FileCacheContract
             if ($stat['size'] === 0) {
                 fclose($handle);
                 $this->delete(new SplFileInfo($cachedPath));
-                return $this->retrieve(...func_get_args());
+                return $this->retrieve($file, $throwOnLock, $attempt + 1);
             }
 
             // The file exists and is no longer written to.
@@ -767,6 +794,7 @@ class FileCache implements FileCacheContract
         foreach ($files as $file) {
             try {
                 $aTime = $file->getATime();
+                $size = $file->getSize();
             } catch (RuntimeException $e) {
                 // This can happen if the file is deleted in the meantime.
                 continue;
@@ -776,7 +804,7 @@ class FileCache implements FileCacheContract
                 continue;
             }
 
-            $totalSize += $file->getSize();
+            $totalSize += $size;
         }
 
         return $totalSize;
@@ -821,7 +849,13 @@ class FileCache implements FileCacheContract
                 break;
             }
 
-            $fileSize = $file->getSize();
+            try {
+                $fileSize = $file->getSize();
+            } catch (RuntimeException $e) {
+                // This can happen if the file is deleted in the meantime.
+                continue;
+            }
+
             if ($this->delete($file)) {
                 $currentSize -= $fileSize;
             }

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -400,7 +400,7 @@ class FileCache implements FileCacheContract
             $stat = fstat($handle);
             // Reference links exist, so the file is still in use. This is an optimization
             // and not strictly required as the check is performed again below.
-            if ($stat['nlink'] > 1) {
+            if ($stat && $stat['nlink'] > 1) {
                 return false;
             }
 
@@ -409,7 +409,7 @@ class FileCache implements FileCacheContract
                 // Re-check after acquiring the lock to guard the race between
                 // the nlink check and the lock acquisition.
                 $stat = fstat($handle);
-                if ($stat['nlink'] === 1) {
+                if ($stat && $stat['nlink'] === 1) {
                     $this->files->delete($path);
                     $deleted = true;
                 }
@@ -598,9 +598,13 @@ class FileCache implements FileCacheContract
         $this->linkCount += 1;
         // Create the reference link while the lock on the canonical file is
         // still held so the pruner cannot delete it before the link exists.
-        link($cachedPath, $link);
+        $success = @link($cachedPath, $link);
 
         fclose($handle);
+
+        if (!$success) {
+            throw new RuntimeException("Failed to create reference link '{$link}' for cached file '{$cachedPath}'.");
+        }
 
         return $link;
     }
@@ -652,10 +656,9 @@ class FileCache implements FileCacheContract
         $dir = $this->lockDir();
         $this->ensureDirExists($dir);
 
-        do {
-            $token = bin2hex(random_bytes(16));
-            $handle = @fopen($this->lockPath($token), 'x');
-        } while ($handle === false);
+        // A token collision is extremely unlikely, no need to guard.
+        $token = bin2hex(random_bytes(16));
+        $handle = @fopen($this->lockPath($token), 'x');
 
         $this->lockToken = $token;
         $this->lockHandle = $handle;
@@ -817,12 +820,11 @@ class FileCache implements FileCacheContract
             ->files()
             ->in($dir)
             ->filter(function (SplFileInfo $file) use ($maxMTime) {
-                if (@filemtime($file) > $maxMTime) {
+                if ($file->getMTime() > $maxMTime) {
                     return false;
                 }
 
-                $token = basename($file);
-                return !$this->isProcessAlive($token);
+                return !$this->isProcessAlive($file->getFilename());
             })
             ->getIterator();
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -493,7 +493,9 @@ class FileCache implements FileCacheContract
             // Remove the empty file if writing failed. This is the case that is caught
             // by 'nlink' === 0 above.
             @unlink($cachedPath);
-            fclose($handle);
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
             throw new Exception("Error while caching file '{$file->getUrl()}': {$e->getMessage()}");
         }
     }

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -514,6 +514,20 @@ class FileCache implements FileCacheContract
         // finished.
         flock($handle, LOCK_EX);
 
+        // Between creating the file with 'x+' and acquiring the lock, another
+        // process may have grabbed a shared lock, seen the empty file and deleted
+        // it. So we check again if the file exists after having the lock.
+        $stat = fstat($handle);
+        if ($stat === false) {
+            fclose($handle);
+            throw new RuntimeException("Could not stat cached file '{$cachedPath}'.");
+        }
+
+        if ($stat['nlink'] === 0) {
+            fclose($handle);
+            return $this->retrieve($file, $throwOnLock, $attempt + 1);
+        }
+
         try {
             return $this->retrieveNewFile($file, $cachedPath, $handle);
         } catch (Exception $e) {

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -20,6 +20,27 @@ use Symfony\Component\Finder\Finder;
  */
 class FileCache implements FileCacheContract
 {
+    /**
+     * Name of the subdirectory in the cache path that holds the per-process
+     * lock files.
+     *
+     * @var string
+     */
+    const LOCK_DIR = '.locks';
+
+    /**
+     * Name of the subdirectory in the cache path that holds the reference links.
+     *
+     * @var string
+     */
+    const REFS_DIR = '.refs';
+
+    /**
+     * Counter for reference links used to generate unique names per instance.
+     *
+     * @var integer
+     */
+    protected $linkCount = 0;
 
     /**
      * File cache configuration.
@@ -50,6 +71,22 @@ class FileCache implements FileCacheContract
     protected $client;
 
     /**
+     * Open file handle holding the exclusive lock that signals this process is
+     * alive. Created lazily and held for the lifetime of the process.
+     *
+     * @var resource|null
+     */
+    protected $lockHandle;
+
+    /**
+     * Unique token identifying this process. Embedded in every reference link
+     * name and used as the name of this process' lock file.
+     *
+     * @var string|null
+     */
+    protected $lockToken;
+
+    /**
      * Create an instance.
      *
      * @param array $config Optional custom configuration.
@@ -62,6 +99,22 @@ class FileCache implements FileCacheContract
         $this->files = $files ?: app('files');
         $this->storage = $storage ?: app('filesystem');
         $this->client = $client ?: $this->makeHttpClient();
+    }
+
+    /**
+     * Release the process lock when the instance is destroyed. If this does not
+     * run (e.g. on a crash) the kernel releases the lock anyway and the orphan
+     * lock file is reaped by the pruner.
+     */
+    public function __destruct()
+    {
+        if (!is_resource($this->lockHandle)) {
+            return;
+        }
+
+        // Also releases the LOCK_EX.
+        fclose($this->lockHandle);
+        @unlink($this->lockPath($this->lockToken));
     }
 
     /**
@@ -149,7 +202,16 @@ class FileCache implements FileCacheContract
             $result = call_user_func($callback, $files, $paths);
         } finally {
             foreach ($retrieved as $file) {
-                fclose($file['handle']);
+                // Locally stored files have no reference link and must not be
+                // deleted.
+                if (is_null($file['link'])) {
+                    continue;
+                }
+
+                // Update the atime so the pruner knows when the file was last used.
+                // May be relevant for (hours-)long batches.
+                @touch($file['link']);
+                @unlink($file['link']);
             }
         }
 
@@ -172,18 +234,15 @@ class FileCache implements FileCacheContract
         try {
             $result = call_user_func($callback, $files, $paths);
         } finally {
-            foreach ($retrieved as $index => $file) {
-                // Convert to exclusive lock for deletion. Don't delete if lock can't be
-                // obtained.
-                if (flock($file['handle'], LOCK_EX | LOCK_NB)) {
-                    // This path is not the same than $file['path'] for locally stored
-                    // files. We don't want to delete locally stored files.
-                    $path = $this->getCachedPath($files[$index]);
-                    if ($this->files->exists($path)) {
-                        $this->files->delete($path);
-                    }
+            foreach ($retrieved as $file) {
+                // Locally stored files have no reference link and must not be
+                // deleted.
+                if (is_null($file['link'])) {
+                    continue;
                 }
-                fclose($file['handle']);
+
+                @unlink($file['link']);
+                $this->delete(new SplFileInfo($file['path']));
             }
         }
 
@@ -199,74 +258,14 @@ class FileCache implements FileCacheContract
             return;
         }
 
-        $now = time();
-        // Allowed age in seconds.
-        $allowedAge = $this->config['max_age'] * 60;
-        $totalSize = 0;
+        // Remove reference links and lock files of crashed workers so that
+        // files only referenced by dead workers become eligible for pruning.
+        $this->pruneStaleReferences();
+        $this->pruneOrphanLockFiles();
 
-        $files = Finder::create()
-            ->files()
-            ->ignoreDotFiles(true)
-            ->in($this->config['path'])
-            ->getIterator();
+        $currentSize = $this->pruneFilesByMaxAge();
 
-        // Prune files by age.
-        foreach ($files as $file) {
-            try {
-                $aTime = $file->getATime();
-            } catch (RuntimeException $e) {
-                // This can happen if the file is deleted in the meantime.
-                continue;
-            }
-
-            if (($now - $aTime) > $allowedAge && $this->delete($file)) {
-                continue;
-            }
-
-            $totalSize += $file->getSize();
-        }
-
-        $allowedSize = $this->config['max_size'];
-
-        // Prune files by cache size.
-        if ($totalSize > $allowedSize) {
-            $files = Finder::create()
-                ->files()
-                ->ignoreDotFiles(true)
-                ->in($this->config['path'])
-                ->getIterator();
-
-            $files = iterator_to_array($files);
-            // This will return the least recently accessed files first.
-            // We use a custom sorting function which ignores errors (because files may
-            // have been deleted in the meantime).
-            uasort($files, function (SplFileInfo $a, SplFileInfo $b) {
-                try {
-                    $aTime = $a->getATime();
-                } catch (RuntimeException $e) {
-                    return 1;
-                }
-
-                try {
-                    $bTime = $b->getATime();
-                } catch (RuntimeException $e) {
-                    return -1;
-                }
-
-                return $aTime - $bTime;
-            });
-
-            foreach ($files as $file) {
-                if ($totalSize <= $allowedSize) {
-                    break;
-                }
-
-                $fileSize = $file->getSize();
-                if ($this->delete($file)) {
-                    $totalSize -= $fileSize;
-                }
-            }
-        }
+        $this->pruneFilesByMaxSize($currentSize);
     }
 
     /**
@@ -278,11 +277,12 @@ class FileCache implements FileCacheContract
             return;
         }
 
-        $files = Finder::create()
-            ->files()
-            ->ignoreDotFiles(true)
-            ->in($this->config['path'])
-            ->getIterator();
+        // Remove reference links and lock files of crashed workers so that
+        // files only referenced by dead workers become eligible for deletion.
+        $this->pruneStaleReferences();
+        $this->pruneOrphanLockFiles();
+
+        $files = $this->canonicalFiles()->getIterator();
 
         foreach ($files as $file) {
             $this->delete($file);
@@ -383,14 +383,36 @@ class FileCache implements FileCacheContract
      */
     protected function delete(SplFileInfo $file)
     {
-        $handle = fopen($file->getRealPath(), 'r');
+        $path = $file->getRealPath();
+        // The file may already be gone (e.g. pruned concurrently).
+        if ($path === false) {
+            return false;
+        }
+
+        $handle = @fopen($path, 'r');
+        if ($handle === false) {
+            return false;
+        }
+
         $deleted = false;
 
         try {
+            $stat = fstat($handle);
+            // Reference links exist, so the file is still in use. This is an optimization
+            // and not strictly required as the check is performed again below.
+            if ($stat['nlink'] > 1) {
+                return false;
+            }
+
             // Only delete the file if it is not currently used. Else move on.
             if (flock($handle, LOCK_EX | LOCK_NB)) {
-                $this->files->delete($file->getRealPath());
-                $deleted = true;
+                // Re-check after acquiring the lock to guard the race between
+                // the nlink check and the lock acquisition.
+                $stat = fstat($handle);
+                if ($stat['nlink'] === 1) {
+                    $this->files->delete($path);
+                    $deleted = true;
+                }
             }
         } finally {
             fclose($handle);
@@ -409,13 +431,13 @@ class FileCache implements FileCacheContract
      * @throws Exception If the file could not be cached.
      * @throws FileLockedException If the file is locked and `throwOnLock` was `true`.
      *
-     *
-     * @return array Containing the 'path' to the file and the file 'handle'. Close the
-     * handle when finished.
+     * @return array Containing the 'path' to the file and the reference 'link'
+     * (or `null` for locally stored files). Unlink the reference link when
+     * finished.
      */
     protected function retrieve(File $file, bool $throwOnLock = false)
     {
-        $this->ensurePathExists();
+        $this->ensureDirExists($this->config['path']);
         $cachedPath = $this->getCachedPath($file);
 
         // This will return false if the file already exists. Else it will create it in
@@ -458,9 +480,7 @@ class FileCache implements FileCacheContract
         flock($handle, LOCK_EX);
 
         try {
-            $fileInfo = $this->retrieveNewFile($file, $cachedPath, $handle);
-            // Convert the lock so other workers can use the file from now on.
-            flock($handle, LOCK_SH);
+            return $this->retrieveNewFile($file, $cachedPath, $handle);
         } catch (Exception $e) {
             // Remove the empty file if writing failed. This is the case that is caught
             // by 'nlink' === 0 above.
@@ -468,12 +488,10 @@ class FileCache implements FileCacheContract
             fclose($handle);
             throw new Exception("Error while caching file '{$file->getUrl()}': {$e->getMessage()}");
         }
-
-        return $fileInfo;
     }
 
     /**
-     * Get path and handle for a file that exists in the cache.
+     * Get path and reference link for a file that exists in the cache.
      *
      * @param string $cachedPath
      * @param resource $handle
@@ -488,12 +506,12 @@ class FileCache implements FileCacheContract
 
         return [
             'path' => $cachedPath,
-            'handle' => $handle,
+            'link' => $this->createReferenceLink($cachedPath, $handle),
         ];
     }
 
     /**
-     * Get path and handle for a file that does not yet exist in the cache.
+     * Get path and reference link for a file that does not yet exist in the cache.
      *
      * @param File $file
      * @param string $cachedPath
@@ -503,6 +521,8 @@ class FileCache implements FileCacheContract
      */
     protected function retrieveNewFile(File $file, $cachedPath, $handle)
     {
+        $isLocal = false;
+
         if ($this->isRemote($file)) {
             $source = $this->getFileStream($file->getUrl());
             try {
@@ -516,9 +536,12 @@ class FileCache implements FileCacheContract
             $newCachedPath = $this->getDiskFile($file, $handle);
 
             // If it is a locally stored file, delete the empty "placeholder"
-            // file again. The handle may stay open; it doesn't matter.
+            // file again. The handle is closed below.
             if ($newCachedPath !== $cachedPath) {
                 unlink($cachedPath);
+                // Locally stored files are not managed by the cache, so they
+                // must not be reference-linked or deleted.
+                $isLocal = true;
             }
 
             $cachedPath = $newCachedPath;
@@ -531,10 +554,313 @@ class FileCache implements FileCacheContract
             }
         }
 
+        $link = null;
+
+        if ($isLocal) {
+            fclose($handle);
+        } else {
+            // Convert the lock so other workers can use the file immediately.
+            flock($handle, LOCK_SH);
+
+            // Non-local (cached) files get a reference link that exists as long as the
+            // file is needed (e.g. during batch()).
+            $link = $this->createReferenceLink($cachedPath, $handle);
+        }
+
         return [
             'path' => $cachedPath,
-            'handle' => $handle,
+            'link' => $link,
         ];
+    }
+
+    /**
+     * Create the reference link that signals the cached file is in use and
+     * release the lock handle.
+     *
+     * @param string $cachedPath
+     * @param resource $handle
+     *
+     * @return string Path to the reference link.
+     */
+    protected function createReferenceLink($cachedPath, $handle): string
+    {
+        // Acquire the process lock before creating the reference link so the
+        // link always has a live, lock-holding owner from the moment it
+        // exists.
+        $this->ensureProcessLock();
+
+        $dir = $this->refsDir();
+        $this->ensureDirExists($dir);
+
+        // The token identifies the owning process. The suffix keeps the
+        // name unique across multiple references held by the same process.
+        $link = "{$dir}/{$this->lockToken}.{$this->linkCount}";
+        $this->linkCount += 1;
+        // Create the reference link while the lock on the canonical file is
+        // still held so the pruner cannot delete it before the link exists.
+        link($cachedPath, $link);
+
+        fclose($handle);
+
+        return $link;
+    }
+
+    /**
+     * Get a Finder for the canonical cache files, excluding reference links and
+     * lock files.
+     *
+     * @return Finder
+     */
+    protected function canonicalFiles(): Finder
+    {
+        return Finder::create()
+            ->files()
+            ->ignoreDotFiles(true)
+            ->exclude(self::REFS_DIR)
+            ->exclude(self::LOCK_DIR)
+            ->in($this->config['path']);
+    }
+
+    /**
+     * Extract the owning process' lock token from a reference link filename.
+     *
+     * @param string $filename
+     *
+     * @return string
+     */
+    protected function referenceLinkToken($filename)
+    {
+        return explode('.', $filename)[0] ?: '';
+    }
+
+    /**
+     * Acquire the lock that signals this process is alive, holding it for the
+     * lifetime of the process.
+     *
+     * The lock is created lazily the first time a reference link is needed. The
+     * kernel releases it when the process exits (including crashes), which is
+     * how the pruner detects that this worker's reference links are stale.
+     * flock also works across (Docker) containers sharing the cache volume because
+     * the lock lives in the host kernel on the shared inode.
+     */
+    protected function ensureProcessLock()
+    {
+        if (is_resource($this->lockHandle)) {
+            return;
+        }
+
+        $dir = $this->lockDir();
+        $this->ensureDirExists($dir);
+
+        do {
+            $token = bin2hex(random_bytes(16));
+            $handle = @fopen($this->lockPath($token), 'x');
+        } while ($handle === false);
+
+        $this->lockToken = $token;
+        $this->lockHandle = $handle;
+        flock($this->lockHandle, LOCK_EX);
+    }
+
+    /**
+     * Determine whether the process owning the given lock token is still alive.
+     *
+     * @return bool
+     */
+    protected function isProcessAlive(string $token)
+    {
+        // This process obviously is alive.
+        if ($token === $this->lockToken) {
+            return true;
+        }
+
+        $handle = @fopen($this->lockPath($token), 'r');
+        // No lock file means the owning process is gone.
+        if ($handle === false) {
+            return false;
+        }
+
+        try {
+            // If the exclusive lock can be acquired, the owning process no
+            // longer holds it and has therefore terminated. The probe lock is
+            // released by the fclose below.
+            if (flock($handle, LOCK_EX | LOCK_NB)) {
+                return false;
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove reference links left behind by crashed workers.
+     */
+    protected function pruneStaleReferences()
+    {
+        $dir = $this->refsDir();
+        if (!$this->files->exists($dir)) {
+            return;
+        }
+
+        $links = Finder::create()
+            ->files()
+            ->in($dir)
+            ->filter(function (SplFileInfo $file) {
+                // We only want to delete references of dead processes.
+                return !$this->isProcessAlive(
+                    $this->referenceLinkToken($file->getFilename())
+                );
+            })
+            ->getIterator();
+
+        foreach ($links as $link) {
+            @unlink($link->getRealPath());
+        }
+    }
+
+    /**
+     * Prune canonical files that are older than max_age.
+     *
+     * @return int The total size in bytes of the remaining files.
+     */
+    protected function pruneFilesByMaxAge(): int
+    {
+        $now = time();
+        // Allowed age in seconds.
+        $allowedAge = $this->config['max_age'] * 60;
+        $totalSize = 0;
+
+        $files = $this->canonicalFiles()->getIterator();
+
+        // Prune files by age.
+        foreach ($files as $file) {
+            try {
+                $aTime = $file->getATime();
+            } catch (RuntimeException $e) {
+                // This can happen if the file is deleted in the meantime.
+                continue;
+            }
+
+            if (($now - $aTime) > $allowedAge && $this->delete($file)) {
+                continue;
+            }
+
+            $totalSize += $file->getSize();
+        }
+
+        return $totalSize;
+    }
+
+    /**
+     * Prune oldest canonical files that exceed the max_size.
+     *
+     * @param int $currentSize Current total size of the files.
+     */
+    protected function pruneFilesByMaxSize(int $currentSize)
+    {
+        $allowedSize = $this->config['max_size'];
+
+        if ($currentSize <= $allowedSize) {
+            return;
+        }
+
+        // This will return the least recently accessed files first.
+        // We use a custom sorting function which ignores errors (because files may
+        // have been deleted in the meantime).
+        $files = $this->canonicalFiles()
+            ->sort(function (SplFileInfo $a, SplFileInfo $b) {
+                try {
+                    $aTime = $a->getATime();
+                } catch (RuntimeException $e) {
+                    return 1;
+                }
+
+                try {
+                    $bTime = $b->getATime();
+                } catch (RuntimeException $e) {
+                    return -1;
+                }
+
+                return $aTime - $bTime;
+            })
+            ->getIterator();
+
+        foreach ($files as $file) {
+            if ($currentSize <= $allowedSize) {
+                break;
+            }
+
+            $fileSize = $file->getSize();
+            if ($this->delete($file)) {
+                $currentSize -= $fileSize;
+            }
+        }
+    }
+
+    /**
+     * Remove lock files of processes that have terminated.
+     */
+    protected function pruneOrphanLockFiles()
+    {
+        $dir = $this->lockDir();
+        if (!$this->files->exists($dir)) {
+            return;
+        }
+
+        // Only consider lock files older than 1 s to rule out the brief window
+        // between creating a fresh lock file and acquiring its lock.
+        $maxMTime = time() - 1;
+
+        $lockFiles = Finder::create()
+            ->files()
+            ->in($dir)
+            ->filter(function (SplFileInfo $file) use ($maxMTime) {
+                if (@filemtime($file) > $maxMTime) {
+                    return false;
+                }
+
+                $token = basename($file);
+                return !$this->isProcessAlive($token);
+            })
+            ->getIterator();
+
+        foreach ($lockFiles as $file) {
+            @unlink($file->getRealPath());
+        }
+    }
+
+    /**
+     * Get the directory in which process lock files are stored.
+     *
+     * @return string
+     */
+    protected function lockDir()
+    {
+        return "{$this->config['path']}/".self::LOCK_DIR;
+    }
+
+    /**
+     * Get the directory in which reference links are stored.
+     *
+     * @return string
+     */
+    protected function refsDir()
+    {
+        return "{$this->config['path']}/".self::REFS_DIR;
+    }
+
+    /**
+     * Get the path to the lock file for the given process token.
+     *
+     * @param string $token
+     *
+     * @return string
+     */
+    protected function lockPath($token)
+    {
+        return "{$this->lockDir()}/{$token}";
     }
 
     /**
@@ -616,12 +942,12 @@ class FileCache implements FileCacheContract
     }
 
     /**
-     * Creates the cache directory if it doesn't exist yet.
+     * Creates the directory if it doesn't exist yet.
      */
-    protected function ensurePathExists()
+    protected function ensureDirExists(string $dir)
     {
-        if (!$this->files->exists($this->config['path'])) {
-            $this->files->makeDirectory($this->config['path'], 0755, true, true);
+        if (!$this->files->exists($dir)) {
+            $this->files->makeDirectory($dir, 0755, true, true);
         }
     }
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -846,7 +846,14 @@ class FileCache implements FileCacheContract
             ->files()
             ->in($dir)
             ->filter(function (SplFileInfo $file) use ($maxMTime) {
-                if ($file->getMTime() > $maxMTime) {
+                try {
+                    $mTime = $file->getMTime();
+                } catch (RuntimeException $e) {
+                    // The lock file may have been deleted concurrently.
+                    return false;
+                }
+
+                if ($mTime > $maxMTime) {
                     return false;
                 }
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -190,15 +190,19 @@ class FileCache implements FileCacheContract
      */
     public function batch(array $files, callable $callback, bool $throwOnLock = false)
     {
-        $retrieved = array_map(function ($file) use ($throwOnLock) {
-            return $this->retrieve($file, $throwOnLock);
-        }, $files);
-
-        $paths = array_map(function ($file) {
-            return $file['path'];
-        }, $retrieved);
+        $retrieved = [];
 
         try {
+            // Must be a loop so $retrieved is populated incrementally. If retrieve()
+            // throws, the finally block can still clean up any links created so far.
+            foreach ($files as $file) {
+                $retrieved[] = $this->retrieve($file, $throwOnLock);
+            }
+
+            $paths = array_map(function ($file) {
+                return $file['path'];
+            }, $retrieved);
+
             $result = call_user_func($callback, $files, $paths);
         } finally {
             foreach ($retrieved as $file) {
@@ -223,15 +227,19 @@ class FileCache implements FileCacheContract
      */
     public function batchOnce(array $files, callable $callback, bool $throwOnLock = false)
     {
-        $retrieved = array_map(function ($file) use ($throwOnLock) {
-            return $this->retrieve($file, $throwOnLock);
-        }, $files);
-
-        $paths = array_map(function ($file) {
-            return $file['path'];
-        }, $retrieved);
+        $retrieved = [];
 
         try {
+            // Must be a loop so $retrieved is populated incrementally. If retrieve()
+            // throws, the finally block can still clean up any links created so far.
+            foreach ($files as $file) {
+                $retrieved[] = $this->retrieve($file, $throwOnLock);
+            }
+
+            $paths = array_map(function ($file) {
+                return $file['path'];
+            }, $retrieved);
+
             $result = call_user_func($callback, $files, $paths);
         } finally {
             foreach ($retrieved as $file) {
@@ -665,6 +673,7 @@ class FileCache implements FileCacheContract
         }
 
         if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
             @unlink($path);
             throw new RuntimeException("Could not get lock on file {$path}");
         }
@@ -715,14 +724,19 @@ class FileCache implements FileCacheContract
             return;
         }
 
+        $alive = [];
         $links = Finder::create()
             ->files()
             ->in($dir)
-            ->filter(function (SplFileInfo $file) {
+            ->filter(function (SplFileInfo $file) use (&$alive) {
+                $token = $this->referenceLinkToken($file->getFilename());
                 // We only want to delete references of dead processes.
-                return !$this->isProcessAlive(
-                    $this->referenceLinkToken($file->getFilename())
-                );
+                // Memoize per token since a worker may hold many links.
+                if (!array_key_exists($token, $alive)) {
+                    $alive[$token] = $this->isProcessAlive($token);
+                }
+
+                return !$alive[$token];
             })
             ->getIterator();
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -658,11 +658,18 @@ class FileCache implements FileCacheContract
 
         // A token collision is extremely unlikely, no need to guard.
         $token = bin2hex(random_bytes(16));
-        $handle = @fopen($this->lockPath($token), 'x');
+        $path = $this->lockPath($token);
+        $handle = @fopen($path, 'x');
+        if ($handle === false) {
+            throw new RuntimeException("Could not create lock file at {$path}");
+        }
+
+        if (!flock($handle, LOCK_EX)) {
+            throw new RuntimeException("Could not get lock on file {$path}");
+        }
 
         $this->lockToken = $token;
         $this->lockHandle = $handle;
-        flock($this->lockHandle, LOCK_EX);
     }
 
     /**
@@ -719,7 +726,9 @@ class FileCache implements FileCacheContract
             ->getIterator();
 
         foreach ($links as $link) {
-            @unlink($link->getRealPath());
+            if (($path = $link->getRealPath())) {
+                @unlink($path);
+            }
         }
     }
 
@@ -829,7 +838,9 @@ class FileCache implements FileCacheContract
             ->getIterator();
 
         foreach ($lockFiles as $file) {
-            @unlink($file->getRealPath());
+            if (($path = $file->getRealPath())) {
+                @unlink($path);
+            }
         }
     }
 

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -372,7 +372,16 @@ class FileCacheTest extends TestCase
     {
         $file = new GenericFile('fixtures://test-image.jpg');
         $hash = hash('sha256', 'fixtures://test-image.jpg');
-        (new FileCache(['path' => $this->cachePath]))->batchOnce([$file], $this->noop);
+        $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->batchOnce([$file], function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // A reference link exists while the callback runs...
+        $this->assertCount(1, $linksDuringCallback);
+        // ...and afterwards both the link and the canonical file are removed.
+        $this->assertCount(0, glob("{$this->cachePath}/.refs/*"));
         $this->assertFalse($this->app['files']->exists("{$this->cachePath}/{$hash}"));
     }
 
@@ -425,7 +434,7 @@ class FileCacheTest extends TestCase
         $this->assertFalse($this->app['files']->exists("{$this->cachePath}/abc"));
     }
 
-    public function testPruneKeepsReferencedFile()
+    public function testPruneByMaxAgeKeepsReferencedFile()
     {
         $this->app['files']->put("{$this->cachePath}/abc", 'abc');
         touch("{$this->cachePath}/abc", time() - 61);
@@ -448,6 +457,34 @@ class FileCacheTest extends TestCase
         // The live reference protects the file and is left in place.
         $this->assertTrue($this->app['files']->exists("{$this->cachePath}/abc"));
         $this->assertTrue($this->app['files']->exists("{$this->cachePath}/.refs/token.0"));
+
+        flock($lock, LOCK_UN);
+        fclose($lock);
+    }
+
+    public function testPruneByMaxSizeKeepsReferencedFile()
+    {
+        $this->app['files']->put("{$this->cachePath}/abc", 'abc');
+
+        $this->app['files']->makeDirectory("{$this->cachePath}/.locks", 0755, false, true);
+        $this->app['files']->makeDirectory("{$this->cachePath}/.refs", 0755, false, true);
+
+        // Simulate a live worker: hold an exclusive lock on its lock file and
+        // keep a reference link to the cached file.
+        $lock = fopen("{$this->cachePath}/.locks/token", 'c');
+        flock($lock, LOCK_EX);
+        link("{$this->cachePath}/abc", "{$this->cachePath}/.refs/token.0");
+
+        // max_size of 0 forces size pruning to want to delete every file. The
+        // file is freshly created, so age pruning leaves it alone.
+        $cache = new FileCache([
+            'path' => $this->cachePath,
+            'max_size' => 0,
+        ]);
+        $cache->prune();
+
+        // The live reference (nlink > 1) protects the file from max-size pruning.
+        $this->assertTrue($this->app['files']->exists("{$this->cachePath}/abc"));
 
         flock($lock, LOCK_UN);
         fclose($lock);

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -374,11 +374,28 @@ class FileCacheTest extends TestCase
         $cache->batch([$file], fn ($file, $path) => $file, true);
     }
 
-    public function testBatchOnce()
+    public function testBatchOnceLocal()
     {
         $file = new GenericFile('fixtures://test-image.jpg');
         $hash = hash('sha256', 'fixtures://test-image.jpg');
         $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->batchOnce([$file], function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // Local files are served from disk, so no reference link or canonical
+        // cache file is created.
+        $this->assertCount(0, $linksDuringCallback);
+        $this->assertFalse($this->app['files']->exists("{$this->cachePath}/{$hash}"));
+    }
+
+    public function testBatchOnceRemote()
+    {
+        $file = new GenericFile('http://test-image.jpg');
+        $hash = hash('sha256', 'http://test-image.jpg');
+        $cache = new FileCacheStub(['path' => $this->cachePath]);
+        $cache->stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
 
         $linksDuringCallback = $cache->batchOnce([$file], function () {
             return glob("{$this->cachePath}/.refs/*");
@@ -531,10 +548,37 @@ class FileCacheTest extends TestCase
         $this->assertFalse($this->app['files']->exists($lockFile));
     }
 
-    public function testGetCreatesReferenceLink()
+    public function testGetLocalCreatesNoReferenceLink()
     {
         $file = new GenericFile('fixtures://test-image.jpg');
         $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->get($file, function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // Local files are served from disk and not reference-linked.
+        $this->assertCount(0, $linksDuringCallback);
+    }
+
+    public function testBatchLocalCreatesNoReferenceLink()
+    {
+        $file = new GenericFile('fixtures://test-image.jpg');
+        $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->batch([$file], function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // Local files are served from disk and not reference-linked.
+        $this->assertCount(0, $linksDuringCallback);
+    }
+
+    public function testGetRemoteCreatesReferenceLink()
+    {
+        $file = new GenericFile('http://test-image.jpg');
+        $cache = new FileCacheStub(['path' => $this->cachePath]);
+        $cache->stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
 
         $linksDuringCallback = $cache->get($file, function () {
             return glob("{$this->cachePath}/.refs/*");
@@ -547,10 +591,11 @@ class FileCacheTest extends TestCase
         $this->assertCount(0, glob("{$this->cachePath}/.refs/*"));
     }
 
-    public function testBatchCreatesReferenceLink()
+    public function testBatchRemoteCreatesReferenceLink()
     {
-        $file = new GenericFile('fixtures://test-image.jpg');
-        $cache = new FileCache(['path' => $this->cachePath]);
+        $file = new GenericFile('http://test-image.jpg');
+        $cache = new FileCacheStub(['path' => $this->cachePath]);
+        $cache->stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
 
         $linksDuringCallback = $cache->batch([$file], function () {
             return glob("{$this->cachePath}/.refs/*");

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -425,6 +425,101 @@ class FileCacheTest extends TestCase
         $this->assertFalse($this->app['files']->exists("{$this->cachePath}/abc"));
     }
 
+    public function testPruneKeepsReferencedFile()
+    {
+        $this->app['files']->put("{$this->cachePath}/abc", 'abc');
+        touch("{$this->cachePath}/abc", time() - 61);
+
+        $this->app['files']->makeDirectory("{$this->cachePath}/.locks", 0755, false, true);
+        $this->app['files']->makeDirectory("{$this->cachePath}/.refs", 0755, false, true);
+
+        // Simulate a live worker: hold an exclusive lock on its lock file and
+        // keep a reference link to the cached file.
+        $lock = fopen("{$this->cachePath}/.locks/token", 'c');
+        flock($lock, LOCK_EX);
+        link("{$this->cachePath}/abc", "{$this->cachePath}/.refs/token.0");
+
+        $cache = new FileCache([
+            'path' => $this->cachePath,
+            'max_age' => 1,
+        ]);
+        $cache->prune();
+
+        // The live reference protects the file and is left in place.
+        $this->assertTrue($this->app['files']->exists("{$this->cachePath}/abc"));
+        $this->assertTrue($this->app['files']->exists("{$this->cachePath}/.refs/token.0"));
+
+        flock($lock, LOCK_UN);
+        fclose($lock);
+    }
+
+    public function testPruneReapsStaleReference()
+    {
+        $this->app['files']->put("{$this->cachePath}/abc", 'abc');
+        touch("{$this->cachePath}/abc", time() - 61);
+
+        $this->app['files']->makeDirectory("{$this->cachePath}/.refs", 0755, false, true);
+        // Reference link of a crashed worker: no lock file exists for its token,
+        // so the owning process counts as dead.
+        link("{$this->cachePath}/abc", "{$this->cachePath}/.refs/token.0");
+
+        $cache = new FileCache([
+            'path' => $this->cachePath,
+            'max_age' => 1,
+        ]);
+        $cache->prune();
+
+        // The stale reference is reaped, which makes the file prunable.
+        $this->assertFalse($this->app['files']->exists("{$this->cachePath}/.refs/token.0"));
+        $this->assertFalse($this->app['files']->exists("{$this->cachePath}/abc"));
+    }
+
+    public function testPruneReapsOrphanLockFile()
+    {
+        $this->app['files']->makeDirectory("{$this->cachePath}/.locks", 0755, false, true);
+        $lockFile = "{$this->cachePath}/.locks/token";
+        // An unlocked lock file old enough to be past the grace window belongs
+        // to a crashed worker.
+        touch($lockFile, time() - 2);
+
+        $cache = new FileCache(['path' => $this->cachePath]);
+        $cache->prune();
+
+        $this->assertFalse($this->app['files']->exists($lockFile));
+    }
+
+    public function testGetCreatesReferenceLink()
+    {
+        $file = new GenericFile('fixtures://test-image.jpg');
+        $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->get($file, function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // A reference link exists while the callback runs (without an open file
+        // handle per file)...
+        $this->assertCount(1, $linksDuringCallback);
+        // ...and is removed once the callback returns.
+        $this->assertCount(0, glob("{$this->cachePath}/.refs/*"));
+    }
+
+    public function testBatchCreatesReferenceLink()
+    {
+        $file = new GenericFile('fixtures://test-image.jpg');
+        $cache = new FileCache(['path' => $this->cachePath]);
+
+        $linksDuringCallback = $cache->batch([$file], function () {
+            return glob("{$this->cachePath}/.refs/*");
+        });
+
+        // A reference link exists while the callback runs (without an open file
+        // handle per file)...
+        $this->assertCount(1, $linksDuringCallback);
+        // ...and is removed once the callback returns.
+        $this->assertCount(0, glob("{$this->cachePath}/.refs/*"));
+    }
+
     public function testMimeTypeWhitelist()
     {
         $cache = new FileCache([


### PR DESCRIPTION
This implements a new mechanism to lock files that are "in use". Before, a LOCK_SH was held for each used file. This could result in "too many open files" errors, e.g. with large batches.

Now there is only one open lock file per FileCache instance. This file determines a unique token. Each file that is "in use" now gets a reference hard link that contains the token. This way the pruner can check which files are still in use. It also supports pruning of files previously requested by crashed processes.

Reference links are kept as long as the files are in use but there is no need to keep open file descriptors for all files.