### PR TITLE
Implement bypass for local files again

### DIFF
--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -552,6 +552,18 @@ class FileCache implements FileCacheContract
         $url = explode('://', $file->getUrl());
         $disk = $this->getDisk($file);
 
+        // Files of the local driver are not cached but used in place. Flysystem 3
+        // no longer exposes the adapter, so the driver is read from the disk
+        // config instead.
+        $driver = $disk->getConfig()['driver'] ?? null;
+        if ($driver === 'local') {
+            if (!$disk->exists($url[1])) {
+                throw new Exception('File does not exist.');
+            }
+
+            return $disk->path($url[1]);
+        }
+
         $source = $disk->readStream($url[1]);
         if (is_null($source)) {
             throw new Exception('File does not exist.');

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -132,8 +132,10 @@ class FileCacheTest extends TestCase
         $hash = hash('sha256', 'test://test-image.jpg');
         $cache = new FileCache(['path' => $this->cachePath]);
 
+        // Files of a local disk are used in place and not copied to the cache.
         $path = $cache->get($file, $this->noop);
-        $this->assertEquals("{$this->cachePath}/{$hash}", $path);
+        $this->assertEquals("{$this->diskPath}/test-image.jpg", $path);
+        $this->assertFalse($this->app['files']->exists("{$this->cachePath}/{$hash}"));
     }
 
     public function testGetDiskLocalDoesNotExist()
@@ -159,6 +161,7 @@ class FileCacheTest extends TestCase
 
         $mock = Mockery::mock();
         $mock->shouldReceive('disk')->once()->with('s3')->andReturn($mock);
+        $mock->shouldReceive('getConfig')->andReturn(['driver' => 's3']);
         $mock->shouldReceive('readStream')->once()->andReturn($stream);
         $this->app['filesystem'] = $mock;
 
@@ -180,6 +183,7 @@ class FileCacheTest extends TestCase
 
         $mock = Mockery::mock();
         $mock->shouldReceive('disk')->once()->with('s3')->andReturn($mock);
+        $mock->shouldReceive('getConfig')->andReturn(['driver' => 's3']);
         $mock->shouldReceive('readStream')->once()->andReturn($stream);
         $this->app['filesystem'] = $mock;
 
@@ -208,6 +212,7 @@ class FileCacheTest extends TestCase
 
         $mock = Mockery::mock();
         $mock->shouldReceive('disk')->once()->with('s3')->andReturn($mock);
+        $mock->shouldReceive('getConfig')->andReturn(['driver' => 's3']);
         $mock->shouldReceive('readStream')->once()->andReturn($stream);
         $this->app['filesystem'] = $mock;
 
@@ -238,15 +243,17 @@ class FileCacheTest extends TestCase
 
     public function testGetIgnoreZeroSize()
     {
-        $cache = new FileCache(['path' => $this->cachePath]);
-        $file = new GenericFile('fixtures://test-file.txt');
-        $hash = hash('sha256', 'fixtures://test-file.txt');
+        // A remote file is used because local disk files are not cached.
+        $file = new GenericFile('https://files/image.jpg');
+        $hash = hash('sha256', 'https://files/image.jpg');
+        $cache = new FileCacheStub(['path' => $this->cachePath]);
+        $cache->stream = fopen(__DIR__.'/files/test-image.jpg', 'r');
 
         $path = "{$this->cachePath}/{$hash}";
         touch($path);
         $this->assertEquals(0, filesize($path));
 
-        $file = $cache->get($file, function ($file, $path) {
+        $cache->get($file, function ($file, $path) {
             return $file;
         });
 
@@ -341,7 +348,6 @@ class FileCacheTest extends TestCase
         $this->app['files']->put("{$this->diskPath}/test-image.jpg", 'abc');
         $file = new GenericFile('test://test-image.jpg');
         $file2 = new GenericFile('test://test-image.jpg');
-        $hash = hash('sha256', 'test://test-image.jpg');
 
         $cache = new FileCache(['path' => $this->cachePath]);
         $paths = $cache->batch([$file, $file2], function ($files, $paths) {
@@ -349,8 +355,8 @@ class FileCacheTest extends TestCase
         });
 
         $this->assertCount(2, $paths);
-        $this->assertStringContainsString($hash, $paths[0]);
-        $this->assertStringContainsString($hash, $paths[1]);
+        $this->assertEquals("{$this->diskPath}/test-image.jpg", $paths[0]);
+        $this->assertEquals("{$this->diskPath}/test-image.jpg", $paths[1]);
     }
 
     public function testBatchThrowOnLock()


### PR DESCRIPTION
This was removed in 8a8bb997bd926edbf285604382cd8cc84e2eca25 but the bypass can still be supported.